### PR TITLE
fixed 3 bugs, changed remarking style

### DIFF
--- a/helpers/DirConvert.bat
+++ b/helpers/DirConvert.bat
@@ -1,7 +1,7 @@
 @ECHO OFF
-:: This script convert a path to an absolute pathname
-:: Parameter 1: input pathname. relative or absolute, with or without double backslashes
-:: Parameter 2: output variable name where the clean path is written to
+REM This script convert a path to an absolute pathname
+REM Parameter 1: input pathname. relative or absolute, with or without double backslashes
+REM Parameter 2: output variable name where the clean path is written to
 IF EXIST %1 (
 	SETLOCAL ENABLEDELAYEDEXPANSION
 	PUSHD %1

--- a/helpers/getPBOName.bat
+++ b/helpers/getPBOName.bat
@@ -1,49 +1,48 @@
-:: This script will determine the PBO-name based on a file's content (last line will be considered for that.
-:: That line may either specify the name as pboName="<The name>" or if it doesn't follow this scheme the complete
-:: last line will be taken as the name.
-:: The given file will be preprocessed before examination so using macros in order to determine the PBO-name is fine.
-:: This script will set the pboName variable that may be accessed in the calling script.
+@ECHO OFF
+REM This script will determine the PBO-name based on a file's content (last line will be considered for that.
+REM That line may either specify the name as pboName="<The name>" or if it doesn't follow this scheme the complete
+REM last line will be taken as the name.
+REM The given file will be preprocessed before examination so using macros in order to determine the PBO-name is fine.
+REM This script will set the pboName variable that may be accessed in the calling script.
 
-:: Param 0: The path to the file containing the pboName
-:: Param 1: The default value that should be used when the extraction of the file fails (The file doesn't exist)
+REM Param 0: The path to the file containing the pboName
+REM Param 1: The default value that should be used when the extraction of the file fails (The file doesn't exist)
 
-@echo off
+SET FILE=%1
+SET default=%2
 
-set FILE=%1
-set default=%2
-
-if [%FILE%] == [] (
-	:: if no FILE is given, use the default
-	set pboName=%default%
-	goto :end
+IF [%FILE%] == [] (
+	REM if no FILE is given, use the default
+	SET pboName=%default%
+	GOTO END
 )
 
-if not exist %FILE% (
-	:: if the given FILE doesn't exist, use the default
-	set pboName=%default%
-	goto :end
-) else (
-	:: preprocess the file into a local file called
+IF NOT EXIST %FILE% (
+	REM if the given FILE doesn't exist, use the default
+	SET pboName=%default%
+	GOTO END
+) ELSE (
+	REM preprocess the file into a local file called
 	"%OptToolsRepoDir%\helpers\armake2.exe" preprocess -i "%OptServerRepoDir%\dependencies\CLib\addons" %FILE% internal_pboName.h.tmp
 	
-	:: read the last line of the file (contains the pboName spec)
-	for /f "delims=" %%x in (internal_pboName.h.tmp) do set pboName=%%x
+	REM read the last line of the file (contains the pboName spec)
+	FOR /F "delims=" %%x IN (internal_pboName.h.tmp) DO SET pboName=%%x
 	
-	:: delete the temp-file
-	del internal_pboName.h.tmp /q
+	REM delete the temp-file
+	DEL internal_pboName.h.tmp /Q
 )
 
 
-:end
-:: replace double-quotes with single quotes as they don't mess up the script on expansion
-set pboName=%pboName:"='%
+:END
+REM replace double-quotes with single quotes as they don't mess up the script on expansion
+SET pboName=%pboName:"='%
 
-if "%pboName:~0,9%" == "pboName='" (
-	:: The pboName is given in the format pboName="<actualName>" -> trim to <actualName>
-	set pboName=%pboName:~9,-1%
+IF "%pboName:~0,9%" == "pboName='" (
+	REM The pboName is given in the format pboName="<actualName>" -> trim to <actualName>
+	SET pboName=%pboName:~9,-1%
 )
 
-if not "%pboName:~4%" == ".pbo" (
-	:: make sure the name actually ends with .pbo
-	set pboName=%pboName%.pbo
+IF NOT "%pboName:~4%" == ".pbo" (
+	REM make sure the name actually ends with .pbo
+	SET pboName=%pboName%.pbo
 )

--- a/helpers/getPBOName.bat
+++ b/helpers/getPBOName.bat
@@ -23,7 +23,7 @@ IF NOT EXIST %FILE% (
 	GOTO END
 ) ELSE (
 	REM preprocess the file into a local file called
-	"%OptToolsRepoDir%\helpers\armake2.exe" preprocess -i "%OptServerRepoDir%\dependencies\CLib\addons" %FILE% internal_pboName.h.tmp
+	"%~dp0.\armake2.exe" preprocess -i "%OptServerRepoDir%\dependencies\CLib\addons" %FILE% internal_pboName.h.tmp
 	
 	REM read the last line of the file (contains the pboName spec)
 	FOR /F "delims=" %%x IN (internal_pboName.h.tmp) DO SET pboName=%%x

--- a/settings/setMetaData.bat.example
+++ b/settings/setMetaData.bat.example
@@ -11,7 +11,6 @@ REM * Set paths to your cloned OPT repositories *
 REM *********************************************
 SET "OptClientRepoDir=n:\OPT-Repos\OPT-Client-Mod\"
 SET "OptServerRepoDir=n:\OPT-Repos\OPT-Server-Mod\"
-SET "OptToolsRepoDir=n:\OPT-Repos\OPT-Tools\"
 SET "OptMissionRepoDir=n:\OPT-Repos\OPT-Mission\"
 
 REM ************************************************
@@ -62,7 +61,6 @@ REM ******************************
 REM Checking if you missed something...
 CALL :CHECK "%%OptClientRepoDir%%"
 CALL :CHECK "%%OptServerRepoDir%%"
-CALL :CHECK "%%OptToolsRepoDir%%"
 CALL :CHECK "%%OptMissionRepoDir%%\%%OptMissionName%%"
 CALL :CHECK "%%OptKeysDir%%"
 CALL :CHECK "%%ArmaGameDir%%\%ArmaServerExe%%"

--- a/settings/setMetaData.bat.example
+++ b/settings/setMetaData.bat.example
@@ -1,43 +1,60 @@
 @ECHO OFF
-REM This file is an example file. You need to copy this file (removing the .example from the name)
-REM and adjust the paths to your local file structure
+REM ****************************************************************
+REM * This file is an example file.                                *
+REM * You need to copy this file (remove ".example" from the name) *
+REM * and adjust the paths to your local file structure            *
+REM ****************************************************************
 
-REM Set paths to your cloned OPT repositories
+REM *********************************************
+REM * Set paths to your cloned OPT repositories *
+REM *********************************************
 SET "OptClientRepoDir=n:\OPT-Repos\OPT-Client-Mod\"
 SET "OptServerRepoDir=n:\OPT-Repos\OPT-Server-Mod\"
 SET "OptToolsRepoDir=n:\OPT-Repos\OPT-Tools\"
 SET "OptMissionRepoDir=n:\OPT-Repos\OPT-Mission\"
 
-REM Set active mission in OPT-Mission repository
+REM ************************************************
+REM * Set active mission in OPT-Mission repository *
+REM ************************************************
 SET "OptMissionName=OPT-TestMission.Altis"
 
-REM Set path to a directory where you securely store your OPT private key
+REM *************************************************************************
+REM * Set path to a directory where you securely store your OPT private key *
+REM *************************************************************************
 SET "OptKeysDir=n:\OPT-Repos\OPT-Keys\"
 
-REM Set ArmA paths
+REM ******************
+REM * Set ArmA paths *
+REM ******************
 SET "ArmaGameDir=C:\Program Files (x86)\Steam\steamapps\common\Arma 3\"
 SET "ArmaMissionPboDir=C:\Program Files (x86)\Steam\steamapps\common\Arma 3\MPMissions\"
 SET "ArmaMissionSourceDir=c:\Users\xxx\Documents\Arma 3\mpmissions\"
 
-REM Set ArmA executables
+REM ************************
+REM * Set ArmA executables *
+REM ************************
 SET "ArmaServerExe=arma3server_x64.exe"
 SET "ArmaClientExe=arma3_x64.exe"
 
-REM @CLib and @OPT* mods will be loaded from your build-directories.
-REM If you need more mods, add them here.
-REM Be sure to use absolute paths if they are not directly in the ArmA-directory.
+REM *********************************************************************************
+REM * @CLib and @OPT* mods will be loaded from your build-directories.              *
+REM * If you need more mods, add them here.                                         *
+REM * Be sure to use absolute paths if they are not directly in the ArmA-directory. *
+REM *********************************************************************************
 SET "additionalMods=m:\OPT-Modset\@CBA_A3;m:\OPT-Modset\@ace;m:\OPT-Modset\@ace_particles;m:\OPT-Modset\@tfar;m:\OPT-Modset\@diwako_dui"
 
-REM If you want to read the script output after finish, set TRUE here
+REM *********************************************************************
+REM * If you want to read the script output after finish, set TRUE here *
+REM *********************************************************************
 SET WaitAtFinish=TRUE
 
-REM If you want the ArmAServer to load the dev- instead of release-build of CLib, set TRUE here 
+REM ***************************************************************************************************
+REM * If you want the ArmAServer to load the dev- instead of release-build of CLib/OPT, set TRUE here *
+REM ***************************************************************************************************
 SET LoadClibDev=FALSE
-
-REM If you want the ArmAServer to load the dev- instead of release-build of OPT-Server, set TRUE here 
 SET LoadOptDev=FALSE
 
-REM DO NOT EDIT BELOW THIS LINE :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+REM *** DO NOT EDIT BELOW THIS LINE ! ***
 
 REM Checking if you missed something...
 CALL :CHECK "%OptClientRepoDir%"

--- a/settings/setMetaData.bat.example
+++ b/settings/setMetaData.bat.example
@@ -32,10 +32,10 @@ SET "additionalMods=m:\OPT-Modset\@CBA_A3;m:\OPT-Modset\@ace;m:\OPT-Modset\@ace_
 SET WaitAtFinish=TRUE
 
 :: If you want the ArmAServer to load the dev- instead of release-build of CLib, set TRUE here 
-SET "LoadClibDev=FALSE"
+SET LoadClibDev=FALSE
 
 :: If you want the ArmAServer to load the dev- instead of release-build of OPT-Server, set TRUE here 
-SET "LoadOptDev=FALSE"
+SET LoadOptDev=FALSE
 
 :: DO NOT EDIT BELOW THIS LINE :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/settings/setMetaData.bat.example
+++ b/settings/setMetaData.bat.example
@@ -2,7 +2,8 @@
 REM ****************************************************************
 REM * This file is an example file.                                *
 REM * You need to copy this file (remove ".example" from the name) *
-REM * and adjust the paths to your local file structure            *
+REM * and adjust the paths to your local file structure.           *
+REM * If you have a pathname with a "%" in it, replace it by "%%"! *
 REM ****************************************************************
 
 REM *********************************************
@@ -54,23 +55,25 @@ REM ****************************************************************************
 SET LoadClibDev=FALSE
 SET LoadOptDev=FALSE
 
-REM *** DO NOT EDIT BELOW THIS LINE ! ***
+REM ******************************
+REM *** DO NOT EDIT BELOW THIS ***
+REM ******************************
 
 REM Checking if you missed something...
-CALL :CHECK "%OptClientRepoDir%"
-CALL :CHECK "%OptServerRepoDir%"
-CALL :CHECK "%OptToolsRepoDir%"
-CALL :CHECK "%OptMissionRepoDir%\%OptMissionName%"
-CALL :CHECK "%OptKeysDir%"
-CALL :CHECK "%ArmaGameDir%\%ArmaServerExe%"
-CALL :CHECK "%ArmaGameDir%\%ArmaClientExe%"
-CALL :CHECK "%ArmaMissionPboDir%"
-CALL :CHECK "%ArmaMissionSourceDir%"
+CALL :CHECK "%%OptClientRepoDir%%"
+CALL :CHECK "%%OptServerRepoDir%%"
+CALL :CHECK "%%OptToolsRepoDir%%"
+CALL :CHECK "%%OptMissionRepoDir%%\%%OptMissionName%%"
+CALL :CHECK "%%OptKeysDir%%"
+CALL :CHECK "%%ArmaGameDir%%\%ArmaServerExe%%"
+CALL :CHECK "%%ArmaGameDir%%\%ArmaClientExe%%"
+CALL :CHECK "%%ArmaMissionPboDir%%"
+CALL :CHECK "%%ArmaMissionSourceDir%%"
 EXIT /B 0
 
 :CHECK
-IF NOT EXIST %* (
-	ECHO %* not found. Check your configuration.
+IF NOT EXIST %1 (
+	ECHO %1 not found. Check your configuration.
 	ECHO Press any key to exit.
 	PAUSE > NUL
 	EXIT 1

--- a/settings/setMetaData.bat.example
+++ b/settings/setMetaData.bat.example
@@ -1,45 +1,45 @@
 @ECHO OFF
-:: This file is an example file. You need to copy this file (removing the .example from the name)
-:: and adjust the paths to your local file structure
+REM This file is an example file. You need to copy this file (removing the .example from the name)
+REM and adjust the paths to your local file structure
 
-:: Set paths to your cloned OPT repositories
+REM Set paths to your cloned OPT repositories
 SET "OptClientRepoDir=n:\OPT-Repos\OPT-Client-Mod\"
 SET "OptServerRepoDir=n:\OPT-Repos\OPT-Server-Mod\"
 SET "OptToolsRepoDir=n:\OPT-Repos\OPT-Tools\"
 SET "OptMissionRepoDir=n:\OPT-Repos\OPT-Mission\"
 
-:: Set active mission in OPT-Mission repository
+REM Set active mission in OPT-Mission repository
 SET "OptMissionName=OPT-TestMission.Altis"
 
-:: Set path to a directory where you securely store your OPT private key
+REM Set path to a directory where you securely store your OPT private key
 SET "OptKeysDir=n:\OPT-Repos\OPT-Keys\"
 
-:: Set ArmA paths
+REM Set ArmA paths
 SET "ArmaGameDir=C:\Program Files (x86)\Steam\steamapps\common\Arma 3\"
 SET "ArmaMissionPboDir=C:\Program Files (x86)\Steam\steamapps\common\Arma 3\MPMissions\"
 SET "ArmaMissionSourceDir=c:\Users\xxx\Documents\Arma 3\mpmissions\"
 
-:: Set ArmA executables
+REM Set ArmA executables
 SET "ArmaServerExe=arma3server_x64.exe"
 SET "ArmaClientExe=arma3_x64.exe"
 
-:: @CLib and @OPT* mods will be loaded from your build-directories.
-:: If you need more mods, add them here.
-:: Be sure to use absolute paths if they are not directly in the ArmA-directory.
+REM @CLib and @OPT* mods will be loaded from your build-directories.
+REM If you need more mods, add them here.
+REM Be sure to use absolute paths if they are not directly in the ArmA-directory.
 SET "additionalMods=m:\OPT-Modset\@CBA_A3;m:\OPT-Modset\@ace;m:\OPT-Modset\@ace_particles;m:\OPT-Modset\@tfar;m:\OPT-Modset\@diwako_dui"
 
-:: If you want to read the script output after finish, set TRUE here
+REM If you want to read the script output after finish, set TRUE here
 SET WaitAtFinish=TRUE
 
-:: If you want the ArmAServer to load the dev- instead of release-build of CLib, set TRUE here 
+REM If you want the ArmAServer to load the dev- instead of release-build of CLib, set TRUE here 
 SET LoadClibDev=FALSE
 
-:: If you want the ArmAServer to load the dev- instead of release-build of OPT-Server, set TRUE here 
+REM If you want the ArmAServer to load the dev- instead of release-build of OPT-Server, set TRUE here 
 SET LoadOptDev=FALSE
 
-:: DO NOT EDIT BELOW THIS LINE :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+REM DO NOT EDIT BELOW THIS LINE :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-:: Checking if you missed something...
+REM Checking if you missed something...
 CALL :CHECK "%OptClientRepoDir%"
 CALL :CHECK "%OptServerRepoDir%"
 CALL :CHECK "%OptToolsRepoDir%"

--- a/tools/buildAll.bat
+++ b/tools/buildAll.bat
@@ -1,6 +1,6 @@
 @ECHO OFF
 ECHO ******************************************************************
-ECHO *** OPT-Rebuild v0.3                                           ***
+ECHO *** OPT-Rebuild v0.31                                          ***
 ECHO *** This script will rebuild all mission/mods. Running         ***
 ECHO *** server/client will be shut down, and restarted afterwards. ***
 ECHO ******************************************************************
@@ -47,7 +47,7 @@ ECHO.
 ECHO All done.
 
 IF [%1] == [noPause] GOTO :EOF
-IF %WaitAtFinish% == TRUE (
+IF ["%WaitAtFinish%"] == ["TRUE"] (
 	ECHO Press any key to exit.
 	PAUSE > NUL
 )

--- a/tools/buildAll.bat
+++ b/tools/buildAll.bat
@@ -5,7 +5,7 @@ ECHO *** This script will rebuild all mission/mods. Running         ***
 ECHO *** server/client will be shut down, and restarted afterwards. ***
 ECHO ******************************************************************
 
-:: Sanity checks
+REM Sanity checks
 IF NOT EXIST "%~dp0.\..\settings\setMetaData.bat" (
 	ECHO setMetaData.bat not found in "settings".
 	ECHO "Check your configuration. (Rename example-file and adjust paths)"
@@ -14,33 +14,33 @@ IF NOT EXIST "%~dp0.\..\settings\setMetaData.bat" (
 	EXIT 1
 )
 
-:: Set meta infos
+REM Set meta infos
 CALL "%~dp0.\..\settings\setMetaData.bat"
 
-:: Check for running ArmaServer and shutdown if running
+REM Check for running ArmaServer and shutdown if running
 TASKLIST /FI "IMAGENAME EQ %ArmaServerExe%" 2> NUL | FIND /I /N "%ArmaServerExe%" > NUL
 IF "%ERRORLEVEL%"=="0" (
 	SET ArmaServerActive=TRUE
 	CALL "%~dp0.\serverStop.bat" noPause
 )
 
-:: Check for running ArmaClient and shutdown if running
+REM Check for running ArmaClient and shutdown if running
 TASKLIST /FI "IMAGENAME EQ %ArmaClientExe%" 2> NUL | FIND /I /N "%ArmaClientExe%" > NUL
 IF "%ERRORLEVEL%"=="0" (
 	SET ArmaClientActive=TRUE
 	CALL "%~dp0.\clientStop.bat" noPause
 )
 
-:: Build all
+REM Build all
 CALL "%~dp0.\buildMission.bat" noPause
 CALL "%~dp0.\buildMod_CLib.bat" noPause
 CALL "%~dp0.\buildMod_OPT-Client.bat" noPause
 CALL "%~dp0.\buildMod_OPT-Server.bat" noPause
 
-:: Restart ArmaServer if it was running before
+REM Restart ArmaServer if it was running before
 IF [%ArmaServerActive%] == [TRUE] CALL "%~dp0.\serverStart.bat" noPause
 
-:: Restart ArmaClient if it was running before
+REM Restart ArmaClient if it was running before
 IF [%ArmaClientActive%] == [TRUE] CALL "%~dp0.\clientStartOnline.bat" noPause
 
 ECHO.

--- a/tools/buildAll.bat
+++ b/tools/buildAll.bat
@@ -1,6 +1,6 @@
 @ECHO OFF
 ECHO ******************************************************************
-ECHO *** OPT-Rebuild v0.31                                          ***
+ECHO *** OPT-Rebuild v0.5                                           ***
 ECHO *** This script will rebuild all mission/mods. Running         ***
 ECHO *** server/client will be shut down, and restarted afterwards. ***
 ECHO ******************************************************************
@@ -15,33 +15,33 @@ IF NOT EXIST "%~dp0.\..\settings\setMetaData.bat" (
 )
 
 REM Set meta infos
-CALL "%~dp0.\..\settings\setMetaData.bat"
+CALL "%%~dp0.\..\settings\setMetaData.bat"
 
 REM Check for running ArmaServer and shutdown if running
 TASKLIST /FI "IMAGENAME EQ %ArmaServerExe%" 2> NUL | FIND /I /N "%ArmaServerExe%" > NUL
 IF "%ERRORLEVEL%"=="0" (
 	SET ArmaServerActive=TRUE
-	CALL "%~dp0.\serverStop.bat" noPause
+	CALL "%%~dp0.\serverStop.bat" noPause
 )
 
 REM Check for running ArmaClient and shutdown if running
 TASKLIST /FI "IMAGENAME EQ %ArmaClientExe%" 2> NUL | FIND /I /N "%ArmaClientExe%" > NUL
 IF "%ERRORLEVEL%"=="0" (
 	SET ArmaClientActive=TRUE
-	CALL "%~dp0.\clientStop.bat" noPause
+	CALL "%%~dp0.\clientStop.bat" noPause
 )
 
 REM Build all
-CALL "%~dp0.\buildMission.bat" noPause
-CALL "%~dp0.\buildMod_CLib.bat" noPause
-CALL "%~dp0.\buildMod_OPT-Client.bat" noPause
-CALL "%~dp0.\buildMod_OPT-Server.bat" noPause
+CALL "%%~dp0.\buildMission.bat" noPause
+CALL "%%~dp0.\buildMod_CLib.bat" noPause
+CALL "%%~dp0.\buildMod_OPT-Client.bat" noPause
+CALL "%%~dp0.\buildMod_OPT-Server.bat" noPause
 
 REM Restart ArmaServer if it was running before
-IF [%ArmaServerActive%] == [TRUE] CALL "%~dp0.\serverStart.bat" noPause
+IF [%ArmaServerActive%] == [TRUE] CALL "%%~dp0.\serverStart.bat" noPause
 
 REM Restart ArmaClient if it was running before
-IF [%ArmaClientActive%] == [TRUE] CALL "%~dp0.\clientStartOnline.bat" noPause
+IF [%ArmaClientActive%] == [TRUE] CALL "%%~dp0.\clientStartOnline.bat" noPause
 
 ECHO.
 ECHO All done.

--- a/tools/buildMission.bat
+++ b/tools/buildMission.bat
@@ -14,7 +14,7 @@ IF NOT EXIST "%~dp0.\..\settings\setMetaData.bat" (
 )
 
 REM Set meta infos
-CALL "%~dp0.\..\settings\setMetaData.bat"
+CALL "%%~dp0.\..\settings\setMetaData.bat"
 
 REM Check/Create symlink for mission folder
 IF NOT EXIST "%ArmaMissionSourceDir%\%OptMissionName%" (
@@ -22,7 +22,7 @@ IF NOT EXIST "%ArmaMissionSourceDir%\%OptMissionName%" (
 	OPENFILES >NUL 2>&1
 	IF ERRORLEVEL 1 (
 		ECHO [101;93mThis batch script once-only requires administrator privileges to create a symlink.[0m
-		ECHO Right-click on %~nx0 and select "[31mRun as administrator[0m".
+		ECHO Right-click on[31m %~nx0 [0mand select "[31mRun as administrator[0m".
 		ECHO Press any key to exit.
 		PAUSE > NUL
 		EXIT 1

--- a/tools/buildMission.bat
+++ b/tools/buildMission.bat
@@ -4,7 +4,7 @@ ECHO *** OPT-Mission builder v0.21               ***
 ECHO *** This script will build the OPT mission. ***
 ECHO ***********************************************
 
-:: Sanity checks
+REM Sanity checks
 IF NOT EXIST "%~dp0.\..\settings\setMetaData.bat" (
 	ECHO setMetaData.bat not found in "settings".
 	ECHO "Check your configuration. (Rename example-file and adjust paths)"
@@ -13,12 +13,12 @@ IF NOT EXIST "%~dp0.\..\settings\setMetaData.bat" (
 	EXIT 1
 )
 
-:: Set meta infos
+REM Set meta infos
 CALL "%~dp0.\..\settings\setMetaData.bat"
 
-:: Check/Create symlink for mission folder
+REM Check/Create symlink for mission folder
 IF NOT EXIST "%ArmaMissionSourceDir%\%OptMissionName%" (
-	:: Folder doesnt exist. Check for administrator privileges to be able to create it...
+	REM Folder doesnt exist. Check for administrator privileges to be able to create it...
 	OPENFILES >NUL 2>&1
 	IF ERRORLEVEL 1 (
 		ECHO [101;93mThis batch script once-only requires administrator privileges to create a symlink.[0m
@@ -30,7 +30,7 @@ IF NOT EXIST "%ArmaMissionSourceDir%\%OptMissionName%" (
 	ECHO Creating symlink...
 	MKLINK /D "%ArmaMissionSourceDir%\%OptMissionName%" "%OptMissionRepoDir%\%OptMissionName%" > NUL
 	) ELSE (
-	:: Folder exists. Write dummy file to source and look if it appears at the destination...	
+	REM Folder exists. Write dummy file to source and look if it appears at the destination...	
 	ECHO Mission-Folder exists. Checking if its a valid symlink...
 	ECHO. > "%OptMissionRepoDir%\%OptMissionName%\LINKCHECK0815.tmp"
 	IF NOT EXIST "%ArmaMissionSourceDir%\%OptMissionName%\LINKCHECK0815.tmp" (

--- a/tools/buildMission.bat
+++ b/tools/buildMission.bat
@@ -1,6 +1,6 @@
 @ECHO OFF
 ECHO ***********************************************
-ECHO *** OPT-Mission builder v0.2                ***
+ECHO *** OPT-Mission builder v0.21               ***
 ECHO *** This script will build the OPT mission. ***
 ECHO ***********************************************
 
@@ -52,7 +52,7 @@ ECHO.
 ECHO Done.
 
 IF [%1] == [noPause] GOTO :EOF
-IF %WaitAtFinish% == TRUE (
+IF ["%WaitAtFinish%"] == ["TRUE"] (
 	ECHO Press any key to exit.
 	PAUSE > NUL
 )

--- a/tools/buildMod_CLib.bat
+++ b/tools/buildMod_CLib.bat
@@ -1,6 +1,6 @@
 @ECHO OFF
 ECHO ********************************************
-ECHO *** CLib-Mod builder v0.21               ***
+ECHO *** CLib-Mod builder v0.3                ***
 ECHO *** This script will build the CLib mod. ***
 ECHO ********************************************
 
@@ -14,7 +14,7 @@ IF NOT EXIST "%~dp0.\..\settings\setMetaData.bat" (
 )
 
 REM Set meta infos
-CALL "%~dp0.\..\settings\setMetaData.bat"
+CALL "%%~dp0.\..\settings\setMetaData.bat"
 
 IF NOT EXIST "%OptServerRepoDir%\dependencies\CLib\addons\CLib\" (
 	ECHO Can't find the CLib submodule - did you initialize it via "git submodule update"?
@@ -24,7 +24,7 @@ IF NOT EXIST "%OptServerRepoDir%\dependencies\CLib\addons\CLib\" (
 )
 
 REM This batch file will set the pboName variable
-CALL "%~dp0.\..\helpers\getPBOName.bat" "%OptServerRepoDir%\dependencies\CLib\addons\CLib\pboName.h" clib
+CALL "%%~dp0.\..\helpers\getPBOName.bat" "%%OptServerRepoDir%%\dependencies\CLib\addons\CLib\pboName.h" clib
 
 REM build release
 IF EXIST "%OptServerRepoDir%\PBOs\release\@CLib\" (

--- a/tools/buildMod_CLib.bat
+++ b/tools/buildMod_CLib.bat
@@ -1,6 +1,6 @@
 @ECHO OFF
 ECHO ********************************************
-ECHO *** CLib-Mod builder v0.2                ***
+ECHO *** CLib-Mod builder v0.21               ***
 ECHO *** This script will build the CLib mod. ***
 ECHO ********************************************
 
@@ -69,7 +69,7 @@ ECHO.
 ECHO Done.
 
 IF [%1] == [noPause] GOTO :EOF
-IF %WaitAtFinish% == TRUE (
+IF ["%WaitAtFinish%"] == ["TRUE"] (
 	ECHO Press any key to exit.
 	PAUSE > NUL
 )

--- a/tools/buildMod_CLib.bat
+++ b/tools/buildMod_CLib.bat
@@ -4,7 +4,7 @@ ECHO *** CLib-Mod builder v0.21               ***
 ECHO *** This script will build the CLib mod. ***
 ECHO ********************************************
 
-:: Sanity checks
+REM Sanity checks
 IF NOT EXIST "%~dp0.\..\settings\setMetaData.bat" (
 	ECHO setMetaData.bat not found in "settings".
 	ECHO "Check your configuration. (Rename example-file and adjust paths)"
@@ -13,7 +13,7 @@ IF NOT EXIST "%~dp0.\..\settings\setMetaData.bat" (
 	EXIT 1
 )
 
-:: Set meta infos
+REM Set meta infos
 CALL "%~dp0.\..\settings\setMetaData.bat"
 
 IF NOT EXIST "%OptServerRepoDir%\dependencies\CLib\addons\CLib\" (
@@ -23,10 +23,10 @@ IF NOT EXIST "%OptServerRepoDir%\dependencies\CLib\addons\CLib\" (
 	EXIT 1
 )
 
-:: This batch file will set the pboName variable
+REM This batch file will set the pboName variable
 CALL "%~dp0.\..\helpers\getPBOName.bat" "%OptServerRepoDir%\dependencies\CLib\addons\CLib\pboName.h" clib
 
-:: build release
+REM build release
 IF EXIST "%OptServerRepoDir%\PBOs\release\@CLib\" (
 	ECHO Deleting old build ...
 	RMDIR /S /Q "%OptServerRepoDir%\PBOs\release\@CLib\"
@@ -40,7 +40,7 @@ IF NOT EXIST "%OptServerRepoDir%\PBOs\release\@CLib\addons\" (
 ECHO Building release version of CLib Mod...
 "%~dp0.\..\helpers\armake2.exe" build  "%OptServerRepoDir%\dependencies\CLib\addons\CLib" "%OptServerRepoDir%\PBOs\release\@CLib\addons\%pboName%"
 	
-:: build dev
+REM build dev
 IF EXIST "%OptServerRepoDir%\PBOs\dev\@CLib\" (
 	ECHO Deleting old build ...
 	RMDIR /S /Q "%OptServerRepoDir%\PBOs\dev\@CLib\"
@@ -53,14 +53,14 @@ IF NOT EXIST "%OptServerRepoDir%\PBOs\dev\@CLib\addons\" (
 
 ECHO Building dev version of the CLib Mod...
 	
-:: in order to build the dev-version the ISDEV macro flag has to be set programmatically
+REM in order to build the dev-version the ISDEV macro flag has to be set programmatically
 COPY /Y "%OptServerRepoDir%\dependencies\CLib\addons\CLib\isDev.hpp" "%OptServerRepoDir%\dependencies\CLib\addons\CLib\isDev.hpp.original" > NUL
 ECHO:>> "%OptServerRepoDir%\dependencies\CLib\addons\CLib\isDev.hpp"
 ECHO #define ISDEV >> "%OptServerRepoDir%\dependencies\CLib\addons\CLib\isDev.hpp"
 
 "%~dp0.\..\helpers\armake2.exe" build -x isDev.hpp.original "%OptServerRepoDir%\dependencies\CLib\addons\CLib" "%OptServerRepoDir%\PBOs\dev\@CLib\addons\%pboName%"
 	
-::restore the isDev.hpp file
+REM restore the isDev.hpp file
 DEL "%OptServerRepoDir%\dependencies\CLib\addons\CLib\isDev.hpp" /Q
 COPY /Y "%OptServerRepoDir%\dependencies\CLib\addons\CLib\isDev.hpp.original" "%OptServerRepoDir%\dependencies\CLib\addons\CLib\isDev.hpp" > NUL
 DEL "%OptServerRepoDir%\dependencies\CLib\addons\CLib\isDev.hpp.original" /Q

--- a/tools/buildMod_OPT-Client.bat
+++ b/tools/buildMod_OPT-Client.bat
@@ -1,6 +1,6 @@
 @ECHO OFF
 ECHO **************************************************
-ECHO *** OPT-Client-Mod builder v0.3                ***
+ECHO *** OPT-Client-Mod builder v0.31               ***
 ECHO *** This script will build the OPT-Client mod. ***
 ECHO **************************************************
 
@@ -52,7 +52,7 @@ ECHO.
 ECHO Done.
 
 IF [%1] == [noPause] GOTO :EOF
-IF %WaitAtFinish% == TRUE (
+IF ["%WaitAtFinish%"] == ["TRUE"] (
 	ECHO Press any key to exit.
 	PAUSE > NUL
 )

--- a/tools/buildMod_OPT-Client.bat
+++ b/tools/buildMod_OPT-Client.bat
@@ -1,6 +1,6 @@
 @ECHO OFF
 ECHO **************************************************
-ECHO *** OPT-Client-Mod builder v0.31               ***
+ECHO *** OPT-Client-Mod builder v0.4                ***
 ECHO *** This script will build the OPT-Client mod. ***
 ECHO **************************************************
 
@@ -14,7 +14,7 @@ IF NOT EXIST "%~dp0.\..\settings\setMetaData.bat" (
 )
 
 REM Set meta infos
-CALL "%~dp0.\..\settings\setMetaData.bat"
+CALL "%%~dp0.\..\settings\setMetaData.bat"
 
 IF EXIST "%OptClientRepoDir%\@OPT-Client\" (
 	ECHO Deleting old build ...

--- a/tools/buildMod_OPT-Client.bat
+++ b/tools/buildMod_OPT-Client.bat
@@ -4,7 +4,7 @@ ECHO *** OPT-Client-Mod builder v0.31               ***
 ECHO *** This script will build the OPT-Client mod. ***
 ECHO **************************************************
 
-:: Sanity checks
+REM Sanity checks
 IF NOT EXIST "%~dp0.\..\settings\setMetaData.bat" (
 	ECHO setMetaData.bat not found in "settings".
 	ECHO "Check your configuration. (Rename example-file and adjust paths)"
@@ -13,7 +13,7 @@ IF NOT EXIST "%~dp0.\..\settings\setMetaData.bat" (
 	EXIT 1
 )
 
-:: Set meta infos
+REM Set meta infos
 CALL "%~dp0.\..\settings\setMetaData.bat"
 
 IF EXIST "%OptClientRepoDir%\@OPT-Client\" (

--- a/tools/buildMod_OPT-Server.bat
+++ b/tools/buildMod_OPT-Server.bat
@@ -1,6 +1,6 @@
 @ECHO OFF
 ECHO **************************************************
-ECHO *** OPT-Server-Mod builder v0.21               ***
+ECHO *** OPT-Server-Mod builder v0.3                ***
 ECHO *** This script will build the OPT-Server mod. ***
 ECHO **************************************************
 
@@ -14,7 +14,7 @@ IF NOT EXIST "%~dp0.\..\settings\setMetaData.bat" (
 )
 
 REM Set meta infos
-CALL "%~dp0.\..\settings\setMetaData.bat"
+CALL "%%~dp0.\..\settings\setMetaData.bat"
 
 IF NOT EXIST "%OptServerRepoDir%\dependencies\CLib\addons\CLib\" (
 	ECHO Can't find the CLib submodule - did you initialize it via "git submodule update"?
@@ -24,7 +24,7 @@ IF NOT EXIST "%OptServerRepoDir%\dependencies\CLib\addons\CLib\" (
 )
 
 REM This batch file will set the pboName variable
-CALL "%~dp0.\..\helpers\getPBOName.bat" "%OptServerRepoDir%\addons\OPT\pboName.h" opt
+CALL "%%~dp0.\..\helpers\getPBOName.bat" "%%OptServerRepoDir%%\addons\OPT\pboName.h" opt
 
 REM build release
 IF EXIST "%OptServerRepoDir%\PBOs\release\@OPT\" (

--- a/tools/buildMod_OPT-Server.bat
+++ b/tools/buildMod_OPT-Server.bat
@@ -4,7 +4,7 @@ ECHO *** OPT-Server-Mod builder v0.21               ***
 ECHO *** This script will build the OPT-Server mod. ***
 ECHO **************************************************
 
-:: Sanity checks
+REM Sanity checks
 IF NOT EXIST "%~dp0.\..\settings\setMetaData.bat" (
 	ECHO setMetaData.bat not found in "settings".
 	ECHO "Check your configuration. (Rename example-file and adjust paths)"
@@ -13,7 +13,7 @@ IF NOT EXIST "%~dp0.\..\settings\setMetaData.bat" (
 	EXIT 1
 )
 
-:: Set meta infos
+REM Set meta infos
 CALL "%~dp0.\..\settings\setMetaData.bat"
 
 IF NOT EXIST "%OptServerRepoDir%\dependencies\CLib\addons\CLib\" (
@@ -23,10 +23,10 @@ IF NOT EXIST "%OptServerRepoDir%\dependencies\CLib\addons\CLib\" (
 	EXIT 1
 )
 
-:: This batch file will set the pboName variable
+REM This batch file will set the pboName variable
 CALL "%~dp0.\..\helpers\getPBOName.bat" "%OptServerRepoDir%\addons\OPT\pboName.h" opt
 
-:: build release
+REM build release
 IF EXIST "%OptServerRepoDir%\PBOs\release\@OPT\" (
 	ECHO Deleting old build ...
 	RMDIR /S /Q "%OptServerRepoDir%\PBOs\release\@OPT\"
@@ -40,7 +40,7 @@ IF NOT EXIST "%OptServerRepoDir%\PBOs\release\@OPT\addons\" (
 ECHO Building release version of OPT Mod...
 "%~dp0.\..\helpers\armake2.exe" build -i "%OptServerRepoDir%\dependencies\CLib\addons" "%OptServerRepoDir%\addons\OPT" "%OptServerRepoDir%\PBOs\release\@OPT\addons\%pboName%"
 
-:: build dev
+REM build dev
 IF EXIST "%OptServerRepoDir%\PBOs\dev\@OPT\" (
 	ECHO Deleting old build ...
 	RMDIR /S /Q "%OptServerRepoDir%\PBOs\dev\@OPT\"
@@ -53,14 +53,14 @@ IF NOT EXIST "%OptServerRepoDir%\PBOs\dev\@OPT\addons\" (
 
 ECHO Building dev version of the OPT Mod...
 	
-:: in order to build the dev-version the ISDEV macro flag has to be set programmatically
+REM in order to build the dev-version the ISDEV macro flag has to be set programmatically
 COPY /Y "%OptServerRepoDir%\addons\OPT\isDev.hpp" "%OptServerRepoDir%\addons\OPT\isDev.hpp.original" > NUL
 ECHO:>> "%OptServerRepoDir%\addons\OPT\isDev.hpp"
 ECHO #define ISDEV >> "%OptServerRepoDir%\addons\OPT\isDev.hpp"
 
 "%~dp0.\..\helpers\armake2.exe" build -i "%OptServerRepoDir%\dependencies\CLib\addons" -x isDev.hpp.original "%OptServerRepoDir%\addons\OPT" "%OptServerRepoDir%\PBOs\dev\@OPT\addons\%pboName%"
 
-::restore the isDev.hpp file
+REM restore the isDev.hpp file
 DEL "%OptServerRepoDir%\addons\OPT\isDev.hpp" /q
 COPY /Y "%OptServerRepoDir%\addons\OPT\isDev.hpp.original" "%OptServerRepoDir%\addons\OPT\isDev.hpp" > NUL
 DEL "%OptServerRepoDir%\addons\OPT\isDev.hpp.original" /q

--- a/tools/buildMod_OPT-Server.bat
+++ b/tools/buildMod_OPT-Server.bat
@@ -1,6 +1,6 @@
 @ECHO OFF
 ECHO **************************************************
-ECHO *** OPT-Server-Mod builder v0.2                ***
+ECHO *** OPT-Server-Mod builder v0.21               ***
 ECHO *** This script will build the OPT-Server mod. ***
 ECHO **************************************************
 
@@ -69,7 +69,7 @@ ECHO.
 ECHO Done.
 
 IF [%1] == [noPause] GOTO :EOF
-IF %WaitAtFinish% == TRUE (
+IF ["%WaitAtFinish%"] == ["TRUE"] (
 	ECHO Press any key to exit.
 	PAUSE > NUL
 )

--- a/tools/clientStartOffline.bat
+++ b/tools/clientStartOffline.bat
@@ -1,6 +1,6 @@
 @ECHO OFF
 ECHO ***********************************************
-ECHO *** OPT-Client starter v0.21                ***
+ECHO *** OPT-Client starter v0.3                 ***
 ECHO *** This script will start an ArmA instance ***
 ECHO *** to debug OPT mission and mods.          ***
 ECHO ***********************************************
@@ -15,10 +15,10 @@ IF NOT EXIST "%~dp0.\..\settings\setMetaData.bat" (
 )
 
 REM Set meta infos
-CALL "%~dp0.\..\settings\setMetaData.bat"
+CALL "%%~dp0.\..\settings\setMetaData.bat"
 
 REM convert mod-dir absolute pathname so arma can read it properly (relative paths and/or double backslashes)
-CALL "%~dp0.\..\helpers\DirConvert.bat" "%OptClientRepoDir%\@OPT-Client" OPT-Client_Dir
+CALL "%%~dp0.\..\helpers\DirConvert.bat" "%%OptClientRepoDir%%\@OPT-Client" OPT-Client_Dir
 
 REM change directory to ArmA directory (in which the client-exe resides)
 CD /D "%ArmaGameDir%"

--- a/tools/clientStartOffline.bat
+++ b/tools/clientStartOffline.bat
@@ -1,6 +1,6 @@
 @ECHO OFF
 ECHO ***********************************************
-ECHO *** OPT-Client starter v0.2                 ***
+ECHO *** OPT-Client starter v0.21                ***
 ECHO *** This script will start an ArmA instance ***
 ECHO *** to debug OPT mission and mods.          ***
 ECHO ***********************************************
@@ -36,7 +36,7 @@ ECHO Done.
 ECHO %* | FINDSTR /C:"noPause" 1>NUL
 IF NOT ERRORLEVEL 1 GOTO :EOF
 
-IF %WaitAtFinish% == TRUE (
+IF ["%WaitAtFinish%"] == ["TRUE"] (
 	ECHO Press any key to exit.
 	PAUSE > NUL
 )

--- a/tools/clientStartOffline.bat
+++ b/tools/clientStartOffline.bat
@@ -5,7 +5,7 @@ ECHO *** This script will start an ArmA instance ***
 ECHO *** to debug OPT mission and mods.          ***
 ECHO ***********************************************
 
-:: Sanity checks
+REM Sanity checks
 IF NOT EXIST "%~dp0.\..\settings\setMetaData.bat" (
 	ECHO setMetaData.bat not found in "settings".
 	ECHO "Check your configuration. (Rename example-file and adjust paths)"
@@ -14,25 +14,25 @@ IF NOT EXIST "%~dp0.\..\settings\setMetaData.bat" (
 	EXIT 1
 )
 
-:: Set meta infos
+REM Set meta infos
 CALL "%~dp0.\..\settings\setMetaData.bat"
 
-:: convert mod-dir absolute pathname so arma can read it properly (relative paths and/or double backslashes)
+REM convert mod-dir absolute pathname so arma can read it properly (relative paths and/or double backslashes)
 CALL "%~dp0.\..\helpers\DirConvert.bat" "%OptClientRepoDir%\@OPT-Client" OPT-Client_Dir
 
-:: change directory to ArmA directory (in which the client-exe resides)
+REM change directory to ArmA directory (in which the client-exe resides)
 CD /D "%ArmaGameDir%"
 
-:: space headed parameter string for noPause-filter in the next step
+REM space headed parameter string for noPause-filter in the next step
 SET "PARAMS= %*"
 
-:: Start the client
+REM Start the client
 START %ArmaClientExe% -noPause -nosplash -world=empty -skipIntro -filePatching -mod="%additionalMods%;%OPT-Client_Dir%" %PARAMS:noPause=%
 
 ECHO.
 ECHO Done.
 
-:: check for "noPause" on any parameter position
+REM check for "noPause" on any parameter position
 ECHO %* | FINDSTR /C:"noPause" 1>NUL
 IF NOT ERRORLEVEL 1 GOTO :EOF
 

--- a/tools/clientStartOnline.bat
+++ b/tools/clientStartOnline.bat
@@ -1,2 +1,2 @@
 @ECHO OFF
-CALL "%~dp0.\clientStartOffline.bat" -connect=localhost -port=2302 %*
+CALL "%%~dp0.\clientStartOffline.bat" -connect=localhost -port=2302 %*

--- a/tools/clientStop.bat
+++ b/tools/clientStop.bat
@@ -4,7 +4,7 @@ ECHO *** ArmA stopper v0.11                               ***
 ECHO *** This script stops a running local ArmA instance. ***
 ECHO ********************************************************
 
-:: Sanity checks
+REM Sanity checks
 IF NOT EXIST "%~dp0.\..\settings\setMetaData.bat" (
 	ECHO setMetaData.bat not found in "settings".
 	ECHO "Check your configuration. (Rename example-file and adjust paths)"
@@ -13,28 +13,28 @@ IF NOT EXIST "%~dp0.\..\settings\setMetaData.bat" (
 	EXIT 1
 )
 
-:: Set meta infos
+REM Set meta infos
 CALL "%~dp0.\..\settings\setMetaData.bat"
 
-:: Kill the client
-:: The loop occurs as long as the killing reports a success status as this means
-:: there was a client process in the process table that was sent a kill-signal
-:: However this also means that the client is still running and as Windows doesn't really
-:: kill the program, we have to continously send the signal until the client is actually dead
+REM Kill the client
+REM The loop occurs as long as the killing reports a success status as this means
+REM there was a client process in the process table that was sent a kill-signal
+REM However this also means that the client is still running and as Windows doesn't really
+REM kill the program, we have to continously send the signal until the client is actually dead
 ECHO Killing the (potentially) running client. This might take a while...
 :killLoop
 	TASKKILL /IM %ArmaClientExe% > NUL 2>&1
 	
 	IF [%errorlevel%] == [0] (
-		:: sleep 100ms
+		REM sleep 100ms
 		CALL "%~dp0.\..\helpers\sleep.bat" 100
 		GOTO :killLoop
 	) ELSE (
-		:: wait another 100ms and check again if the client was _really_ (hard)killed
+		REM wait another 100ms and check again if the client was _really_ (hard)killed
 		CALL "%~dp0.\..\helpers\sleep.bat" 100
 		TASKKILL /F /IM %ArmaClientExe% > NUL 2>&1
 		IF [%errorlevel%] == [0] (
-			:: apparently the client isn't as dead as it seemed
+			REM apparently the client isn't as dead as it seemed
 			GOTO :killLoop
 		)
 	)

--- a/tools/clientStop.bat
+++ b/tools/clientStop.bat
@@ -1,6 +1,6 @@
 @ECHO OFF
 ECHO ********************************************************
-ECHO *** ArmA stopper v0.11                               ***
+ECHO *** ArmA stopper v0.2                                ***
 ECHO *** This script stops a running local ArmA instance. ***
 ECHO ********************************************************
 
@@ -21,23 +21,31 @@ REM The loop occurs as long as the killing reports a success status as this mean
 REM there was a client process in the process table that was sent a kill-signal
 REM However this also means that the client is still running and as Windows doesn't really
 REM kill the program, we have to continously send the signal until the client is actually dead
+
 ECHO Killing the (potentially) running client. This might take a while...
-:killLoop
-	TASKKILL /IM %ArmaClientExe% > NUL 2>&1
-	
-	IF [%errorlevel%] == [0] (
-		REM sleep 100ms
-		CALL "%~dp0.\..\helpers\sleep.bat" 100
-		GOTO :killLoop
-	) ELSE (
-		REM wait another 100ms and check again if the client was _really_ (hard)killed
-		CALL "%~dp0.\..\helpers\sleep.bat" 100
-		TASKKILL /F /IM %ArmaClientExe% > NUL 2>&1
-		IF [%errorlevel%] == [0] (
-			REM apparently the client isn't as dead as it seemed
-			GOTO :killLoop
-		)
-	)
+:SoftKillLoop
+TASKKILL /IM %ArmaClientExe% > NUL 2>&1
+IF [%errorlevel%] == [0] (
+	REM sleep 100ms
+	CALL "%~dp0.\..\helpers\sleep.bat" 100
+	GOTO SoftKillLoop
+) ELSE (
+	:HardKillLoop
+	REM sleep 100ms
+	CALL "%~dp0.\..\helpers\sleep.bat" 100
+
+	REM Hardkill
+	TASKKILL /F /IM %ArmaClientExe% > NUL 2>&1
+
+	REM Task still active? -> Loop again
+	TASKLIST /FI "IMAGENAME EQ %ArmaClientExe%" 2> NUL | FIND /I /N "%ArmaClientExe%" > NUL
+	IF "%ERRORLEVEL%"=="0" GOTO HardKillLoop
+
+	REM Check (for reappearing ghost-process) again after short delay
+	CALL "%~dp0.\..\helpers\sleep.bat" 100
+	TASKLIST /FI "IMAGENAME EQ %ArmaClientExe%" 2> NUL | FIND /I /N "%ArmaClientExe%" > NUL
+	IF "%ERRORLEVEL%"=="0" GOTO HardKillLoop
+)
 ECHO.
 ECHO Successfully killed the client
 

--- a/tools/clientStop.bat
+++ b/tools/clientStop.bat
@@ -1,6 +1,6 @@
 @ECHO OFF
 ECHO ********************************************************
-ECHO *** ArmA stopper v0.1                                ***
+ECHO *** ArmA stopper v0.11                               ***
 ECHO *** This script stops a running local ArmA instance. ***
 ECHO ********************************************************
 
@@ -42,7 +42,7 @@ ECHO.
 ECHO Successfully killed the client
 
 IF [%1] == [noPause] GOTO :EOF
-IF %WaitAtFinish% == TRUE (
+IF ["%WaitAtFinish%"] == ["TRUE"] (
 	ECHO Press any key to exit.
 	PAUSE > NUL
 )

--- a/tools/clientStop.bat
+++ b/tools/clientStop.bat
@@ -1,6 +1,6 @@
 @ECHO OFF
 ECHO ********************************************************
-ECHO *** ArmA stopper v0.2                                ***
+ECHO *** ArmA stopper v0.3                                ***
 ECHO *** This script stops a running local ArmA instance. ***
 ECHO ********************************************************
 
@@ -14,7 +14,7 @@ IF NOT EXIST "%~dp0.\..\settings\setMetaData.bat" (
 )
 
 REM Set meta infos
-CALL "%~dp0.\..\settings\setMetaData.bat"
+CALL "%%~dp0.\..\settings\setMetaData.bat"
 
 REM Kill the client
 REM The loop occurs as long as the killing reports a success status as this means
@@ -27,12 +27,12 @@ ECHO Killing the (potentially) running client. This might take a while...
 TASKKILL /IM %ArmaClientExe% > NUL 2>&1
 IF [%errorlevel%] == [0] (
 	REM sleep 100ms
-	CALL "%~dp0.\..\helpers\sleep.bat" 100
+	CALL "%%~dp0.\..\helpers\sleep.bat" 100
 	GOTO SoftKillLoop
 ) ELSE (
 	:HardKillLoop
 	REM sleep 100ms
-	CALL "%~dp0.\..\helpers\sleep.bat" 100
+	CALL "%%~dp0.\..\helpers\sleep.bat" 100
 
 	REM Hardkill
 	TASKKILL /F /IM %ArmaClientExe% > NUL 2>&1
@@ -42,7 +42,7 @@ IF [%errorlevel%] == [0] (
 	IF "%ERRORLEVEL%"=="0" GOTO HardKillLoop
 
 	REM Check (for reappearing ghost-process) again after short delay
-	CALL "%~dp0.\..\helpers\sleep.bat" 100
+	CALL "%%~dp0.\..\helpers\sleep.bat" 100
 	TASKLIST /FI "IMAGENAME EQ %ArmaClientExe%" 2> NUL | FIND /I /N "%ArmaClientExe%" > NUL
 	IF "%ERRORLEVEL%"=="0" GOTO HardKillLoop
 )

--- a/tools/serverRestart.bat
+++ b/tools/serverRestart.bat
@@ -1,3 +1,3 @@
 @ECHO OFF
-CALL "%~dp0.\serverStop.bat" noPause
-CALL "%~dp0.\serverStart.bat"
+CALL "%%~dp0.\serverStop.bat" noPause
+CALL "%%~dp0.\serverStart.bat"

--- a/tools/serverStart.bat
+++ b/tools/serverStart.bat
@@ -5,7 +5,7 @@ ECHO *** This script will start a DevServer ***
 ECHO *** to debug OPT mission and mods.     ***
 ECHO ******************************************
 
-:: Sanity checks
+REM Sanity checks
 IF NOT EXIST "%~dp0.\..\settings\setMetaData.bat" (
 	ECHO setMetaData.bat not found in "settings".
 	ECHO "Check your configuration. (Rename example-file and adjust paths)"
@@ -14,23 +14,23 @@ IF NOT EXIST "%~dp0.\..\settings\setMetaData.bat" (
 	EXIT 1
 )
 
-:: Set meta infos
+REM Set meta infos
 CALL "%~dp0.\..\settings\setMetaData.bat"
 
-:: Replace Mission-Name in server config
+REM Replace Mission-Name in server config
 CALL "%~dp0.\..\helpers\JREPL.BAT" "MISSIONTEMPLATE" "%OptMissionName%" /F "%~dp0.\..\settings\serverConfig.cfg" > "%TEMP%\serverConfig.cfg"
 
-:: Copy server-config into arma-dir as ArmA can only read configs relative to the exe
+REM Copy server-config into arma-dir as ArmA can only read configs relative to the exe
 ECHO Trying to copy config file. This might take a while...
 :copyLoop
 MOVE /Y "%TEMP%\serverConfig.cfg" "%ArmaGameDir%" > NUL 2>&1
 IF NOT [%errorlevel%] == [0]  (
-	:: sleep 100ms
+	REM sleep 100ms
 	CALL "%~dp0.\..\helpers\sleep.bat" 100
 	GOTO :copyLoop
 )
 
-:: convert to absolute pathnames so armaserver can read it properly (relative paths and/or double backslashes)
+REM convert to absolute pathnames so armaserver can read it properly (relative paths and/or double backslashes)
 CALL "%~dp0.\..\helpers\DirConvert.bat" "%OptClientRepoDir%\@OPT-Client" OPT-Client_Dir
 
 IF ["%LoadClibDev%"] == ["TRUE"] (
@@ -45,10 +45,10 @@ IF ["%LoadOptDev%"] == ["TRUE"] (
 	CALL "%~dp0.\..\helpers\DirConvert.bat" "%OptServerRepoDir%\PBOs\release\@OPT" OPT-Server_Dir
 )
 
-:: change directory to ArmA directory (in which the server-exe resides)
+REM change directory to ArmA directory (in which the server-exe resides)
 CD /D "%ArmaGameDir%"
 
-:: Start the server and minimize it once it's started
+REM Start the server and minimize it once it's started
 START /MIN %ArmaServerExe% -config=serverConfig.cfg -profiles=OPT_DevServer -filePatching -serverMod="%CLib_Dir%;%OPT-Server_Dir%" -mod="%OPT-Client_Dir%;%additionalMods%" -debugCallExtension
 
 ECHO.

--- a/tools/serverStart.bat
+++ b/tools/serverStart.bat
@@ -1,6 +1,6 @@
 @ECHO OFF
 ECHO ******************************************
-ECHO *** OPT-DevServer starter v0.1         ***
+ECHO *** OPT-DevServer starter v0.21        ***
 ECHO *** This script will start a DevServer ***
 ECHO *** to debug OPT mission and mods.     ***
 ECHO ******************************************
@@ -33,13 +33,13 @@ IF NOT [%errorlevel%] == [0]  (
 :: convert to absolute pathnames so armaserver can read it properly (relative paths and/or double backslashes)
 CALL "%~dp0.\..\helpers\DirConvert.bat" "%OptClientRepoDir%\@OPT-Client" OPT-Client_Dir
 
-IF %LoadClibDev% == TRUE (
+IF ["%LoadClibDev%"] == ["TRUE"] (
 	CALL "%~dp0.\..\helpers\DirConvert.bat" "%OptServerRepoDir%\PBOs\dev\@CLib" CLib_Dir
 ) ELSE (
 	CALL "%~dp0.\..\helpers\DirConvert.bat" "%OptServerRepoDir%\PBOs\release\@CLib" CLib_Dir
 )
 
-IF %LoadOptDev% == TRUE (
+IF ["%LoadOptDev%"] == ["TRUE"] (
 	CALL "%~dp0.\..\helpers\DirConvert.bat" "%OptServerRepoDir%\PBOs\dev\@OPT" OPT-Server_Dir
 ) ELSE (
 	CALL "%~dp0.\..\helpers\DirConvert.bat" "%OptServerRepoDir%\PBOs\release\@OPT" OPT-Server_Dir
@@ -55,7 +55,7 @@ ECHO.
 ECHO Done.
 
 IF [%1] == [noPause] GOTO :EOF
-IF %WaitAtFinish% == TRUE (
+IF ["%WaitAtFinish%"] == ["TRUE"] (
 	ECHO Press any key to exit.
 	PAUSE > NUL
 )

--- a/tools/serverStart.bat
+++ b/tools/serverStart.bat
@@ -1,6 +1,6 @@
 @ECHO OFF
 ECHO ******************************************
-ECHO *** OPT-DevServer starter v0.21        ***
+ECHO *** OPT-DevServer starter v0.3         ***
 ECHO *** This script will start a DevServer ***
 ECHO *** to debug OPT mission and mods.     ***
 ECHO ******************************************
@@ -15,10 +15,10 @@ IF NOT EXIST "%~dp0.\..\settings\setMetaData.bat" (
 )
 
 REM Set meta infos
-CALL "%~dp0.\..\settings\setMetaData.bat"
+CALL "%%~dp0.\..\settings\setMetaData.bat"
 
 REM Replace Mission-Name in server config
-CALL "%~dp0.\..\helpers\JREPL.BAT" "MISSIONTEMPLATE" "%OptMissionName%" /F "%~dp0.\..\settings\serverConfig.cfg" > "%TEMP%\serverConfig.cfg"
+CALL "%%~dp0.\..\helpers\JREPL.BAT" "MISSIONTEMPLATE" "%%OptMissionName%%" /F "%%~dp0.\..\settings\serverConfig.cfg" > "%TEMP%\serverConfig.cfg"
 
 REM Copy server-config into arma-dir as ArmA can only read configs relative to the exe
 ECHO Trying to copy config file. This might take a while...
@@ -26,23 +26,23 @@ ECHO Trying to copy config file. This might take a while...
 MOVE /Y "%TEMP%\serverConfig.cfg" "%ArmaGameDir%" > NUL 2>&1
 IF NOT [%errorlevel%] == [0]  (
 	REM sleep 100ms
-	CALL "%~dp0.\..\helpers\sleep.bat" 100
+	CALL "%%~dp0.\..\helpers\sleep.bat" 100
 	GOTO :copyLoop
 )
 
 REM convert to absolute pathnames so armaserver can read it properly (relative paths and/or double backslashes)
-CALL "%~dp0.\..\helpers\DirConvert.bat" "%OptClientRepoDir%\@OPT-Client" OPT-Client_Dir
+CALL "%%~dp0.\..\helpers\DirConvert.bat" "%%OptClientRepoDir%%\@OPT-Client" OPT-Client_Dir
 
 IF ["%LoadClibDev%"] == ["TRUE"] (
-	CALL "%~dp0.\..\helpers\DirConvert.bat" "%OptServerRepoDir%\PBOs\dev\@CLib" CLib_Dir
+	CALL "%%~dp0.\..\helpers\DirConvert.bat" "%%OptServerRepoDir%%\PBOs\dev\@CLib" CLib_Dir
 ) ELSE (
-	CALL "%~dp0.\..\helpers\DirConvert.bat" "%OptServerRepoDir%\PBOs\release\@CLib" CLib_Dir
+	CALL "%%~dp0.\..\helpers\DirConvert.bat" "%%OptServerRepoDir%%\PBOs\release\@CLib" CLib_Dir
 )
 
 IF ["%LoadOptDev%"] == ["TRUE"] (
-	CALL "%~dp0.\..\helpers\DirConvert.bat" "%OptServerRepoDir%\PBOs\dev\@OPT" OPT-Server_Dir
+	CALL "%%~dp0.\..\helpers\DirConvert.bat" "%%OptServerRepoDir%%\PBOs\dev\@OPT" OPT-Server_Dir
 ) ELSE (
-	CALL "%~dp0.\..\helpers\DirConvert.bat" "%OptServerRepoDir%\PBOs\release\@OPT" OPT-Server_Dir
+	CALL "%%~dp0.\..\helpers\DirConvert.bat" "%%OptServerRepoDir%%\PBOs\release\@OPT" OPT-Server_Dir
 )
 
 REM change directory to ArmA directory (in which the server-exe resides)

--- a/tools/serverStop.bat
+++ b/tools/serverStop.bat
@@ -1,6 +1,6 @@
 @ECHO OFF
 ECHO *************************************************
-ECHO *** OPT-DevServer stopper v0.1                ***
+ECHO *** OPT-DevServer stopper v0.11               ***
 ECHO *** This script stops a local arma dev-server ***
 ECHO *************************************************
 
@@ -42,7 +42,7 @@ ECHO.
 ECHO Successfully killed the server
 
 IF [%1] == [noPause] GOTO :EOF
-IF %WaitAtFinish% == TRUE (
+IF ["%WaitAtFinish%"] == ["TRUE"] (
 	ECHO Press any key to exit.
 	PAUSE > NUL
 )

--- a/tools/serverStop.bat
+++ b/tools/serverStop.bat
@@ -1,10 +1,10 @@
 @ECHO OFF
 ECHO *************************************************
-ECHO *** OPT-DevServer stopper v0.11               ***
+ECHO *** OPT-DevServer stopper v0.2                ***
 ECHO *** This script stops a local arma dev-server ***
 ECHO *************************************************
 
-:: Sanity checks
+REM Sanity checks
 IF NOT EXIST "%~dp0.\..\settings\setMetaData.bat" (
 	ECHO setMetaData.bat not found in "settings".
 	ECHO "Check your configuration. (Rename example-file and adjust paths)"
@@ -13,31 +13,39 @@ IF NOT EXIST "%~dp0.\..\settings\setMetaData.bat" (
 	EXIT 1
 )
 
-:: Set meta infos
+REM Set meta infos
 CALL "%~dp0.\..\settings\setMetaData.bat"
 
-:: Kill the server
-:: The loop occurs as long as the killing reports a success status as this means
-:: there was a server process in the process table that was sent a kill-signal
-:: However this also means that the server is still running and as Windows doesn't really
-:: kill the program, we have to continously send the signal until the server is actually dead
+REM Kill the server
+REM The loop occurs as long as the killing reports a success status as this means
+REM there was a server process in the process table that was sent a kill-signal
+REM However this also means that the server is still running and as Windows doesn't really
+REM kill the program, we have to continously send the signal until the server is actually dead
+
 ECHO Killing the (potentially) running server. This might take a while...
-:killLoop
-	TASKKILL /IM %ArmaServerExe% > NUL 2>&1
-	
-	IF [%errorlevel%] == [0] (
-		:: sleep 100ms
-		CALL "%~dp0.\..\helpers\sleep.bat" 100
-		GOTO :killLoop
-	) ELSE (
-		:: wait another 100ms and check again if the server was _really_ (hard)killed
-		CALL "%~dp0.\..\helpers\sleep.bat" 100
-		TASKKILL /F /IM %ArmaServerExe% > NUL 2>&1
-		IF [%errorlevel%] == [0] (
-			:: apparently the server isn't as dead as it seemed
-			GOTO :killLoop
-		)
-	)
+:SoftKillLoop
+TASKKILL /IM %ArmaServerExe% > NUL 2>&1
+IF [%errorlevel%] == [0] (
+	REM sleep 100ms
+	CALL "%~dp0.\..\helpers\sleep.bat" 100
+	GOTO SoftKillLoop
+) ELSE (
+	:HardKillLoop
+	REM sleep 100ms
+	CALL "%~dp0.\..\helpers\sleep.bat" 100
+
+	REM Hardkill
+	TASKKILL /F /IM %ArmaServerExe% > NUL 2>&1
+
+	REM Task still active? -> Loop again
+	TASKLIST /FI "IMAGENAME EQ %ArmaServerExe%" 2> NUL | FIND /I /N "%ArmaServerExe%" > NUL
+	IF "%ERRORLEVEL%"=="0" GOTO HardKillLoop
+
+	REM Check (for reappearing ghost-process) again after short delay
+	CALL "%~dp0.\..\helpers\sleep.bat" 100
+	TASKLIST /FI "IMAGENAME EQ %ArmaServerExe%" 2> NUL | FIND /I /N "%ArmaServerExe%" > NUL
+	IF "%ERRORLEVEL%"=="0" GOTO HardKillLoop
+)
 ECHO.
 ECHO Successfully killed the server
 

--- a/tools/serverStop.bat
+++ b/tools/serverStop.bat
@@ -1,6 +1,6 @@
 @ECHO OFF
 ECHO *************************************************
-ECHO *** OPT-DevServer stopper v0.2                ***
+ECHO *** OPT-DevServer stopper v0.3                ***
 ECHO *** This script stops a local arma dev-server ***
 ECHO *************************************************
 
@@ -14,7 +14,7 @@ IF NOT EXIST "%~dp0.\..\settings\setMetaData.bat" (
 )
 
 REM Set meta infos
-CALL "%~dp0.\..\settings\setMetaData.bat"
+CALL "%%~dp0.\..\settings\setMetaData.bat"
 
 REM Kill the server
 REM The loop occurs as long as the killing reports a success status as this means
@@ -27,12 +27,12 @@ ECHO Killing the (potentially) running server. This might take a while...
 TASKKILL /IM %ArmaServerExe% > NUL 2>&1
 IF [%errorlevel%] == [0] (
 	REM sleep 100ms
-	CALL "%~dp0.\..\helpers\sleep.bat" 100
+	CALL "%%~dp0.\..\helpers\sleep.bat" 100
 	GOTO SoftKillLoop
 ) ELSE (
 	:HardKillLoop
 	REM sleep 100ms
-	CALL "%~dp0.\..\helpers\sleep.bat" 100
+	CALL "%%~dp0.\..\helpers\sleep.bat" 100
 
 	REM Hardkill
 	TASKKILL /F /IM %ArmaServerExe% > NUL 2>&1
@@ -42,7 +42,7 @@ IF [%errorlevel%] == [0] (
 	IF "%ERRORLEVEL%"=="0" GOTO HardKillLoop
 
 	REM Check (for reappearing ghost-process) again after short delay
-	CALL "%~dp0.\..\helpers\sleep.bat" 100
+	CALL "%%~dp0.\..\helpers\sleep.bat" 100
 	TASKLIST /FI "IMAGENAME EQ %ArmaServerExe%" 2> NUL | FIND /I /N "%ArmaServerExe%" > NUL
 	IF "%ERRORLEVEL%"=="0" GOTO HardKillLoop
 )


### PR DESCRIPTION
- fix: ignore missing optional flags in config (thx @WGPSenshi for reporting this issue)
- fix: making stop-scripts more reliable to avoid file-access problems on rebuild (thx @WGPSenshi for reporting this issue)
- change: comments in batch files are now using "REM" instead of "::" because this dont work inside of nested logic and other advanced environments.
- fix: path-checks don´t fail on pathnames which contains "%", when you escape them with "%%" (thx @oppa-schneutzel for having such weird profile name)