### PR TITLE
Live-Log Viewer und Livonia Modremoval

### DIFF
--- a/settings/setMetaData.bat.example
+++ b/settings/setMetaData.bat.example
@@ -41,7 +41,7 @@ REM * @CLib and @OPT* mods will be loaded from your build-directories.          
 REM * If you need more mods, add them here.                                         *
 REM * Be sure to use absolute paths if they are not directly in the ArmA-directory. *
 REM *********************************************************************************
-SET "additionalMods=m:\OPT-Modset\@CBA_A3;m:\OPT-Modset\@ace;m:\OPT-Modset\@tfar;m:\OPT-Modset\@diwako_dui;m:\OPT-Modset\@rosche;m:\OPT-Modset\@cup_terrains_core"
+SET "additionalMods=m:\OPT-Modset\@CBA_A3;m:\OPT-Modset\@ace;m:\OPT-Modset\@tfar;m:\OPT-Modset\@diwako_dui"
 
 REM *********************************************************************
 REM * If you want to read the script output after finish, set TRUE here *

--- a/settings/setMetaData.bat.example
+++ b/settings/setMetaData.bat.example
@@ -54,6 +54,11 @@ REM ****************************************************************************
 SET LoadClibDev=FALSE
 SET LoadOptDev=FALSE
 
+REM **************************************************************************
+REM * If you want a live-view of the server-log while running, set TRUE here *
+REM **************************************************************************
+SET ShowServerLog=TRUE
+
 REM ******************************
 REM *** DO NOT EDIT BELOW THIS ***
 REM ******************************

--- a/tools/serverLog.bat
+++ b/tools/serverLog.bat
@@ -1,0 +1,49 @@
+@ECHO OFF
+ECHO ******************************************
+ECHO *** OPT-DevServer LogfileViewer v0.1   ***
+ECHO *** This script will provide a         ***
+ECHO *** live-view of the server logfile.   ***
+ECHO ******************************************
+
+REM Sanity checks
+IF NOT EXIST "%~dp0.\..\settings\setMetaData.bat" (
+	ECHO setMetaData.bat not found in "settings".
+	ECHO "Check your configuration. (Rename example-file and adjust paths)"
+	ECHO Press any key to exit.
+	PAUSE > NUL
+	EXIT 1
+)
+
+REM Set meta infos
+CALL "%%~dp0.\..\settings\setMetaData.bat"
+
+REM change directory to ArmA directory (in which the server-exe resides)
+CD /D "%ArmaGameDir%"
+
+REM Loop until (at least one) logfile is found
+:LOOPLOGFILE
+IF EXIST "OPT_DevServer\*.rpt" GOTO GETLOGFILE
+ECHO No logfile found yet. Waiting a bit...
+CALL "%%~dp0.\..\helpers\sleep.bat" 250
+GOTO LOOPLOGFILE
+
+REM Get filename of the last logfile
+:GETLOGFILE
+FOR /F "TOKENS=1" %%a IN ('DIR /B /O-N "OPT_DevServer\*.rpt"') DO (
+	SET "LOGFILE=%%a"
+	GOTO SHOWLOG
+)
+
+REM Show logfile in new powershell-window
+:SHOWLOG
+ECHO Opening new powershell window to show the logfile...
+START POWERSHELL -command "Get-Content OPT_DevServer\%LOGFILE% -Wait -Tail 30"
+
+ECHO.
+ECHO Done.
+
+IF [%1] == [noPause] GOTO :EOF
+IF ["%WaitAtFinish%"] == ["TRUE"] (
+	ECHO Press any key to exit.
+	PAUSE > NUL
+)

--- a/tools/serverStart.bat
+++ b/tools/serverStart.bat
@@ -49,7 +49,15 @@ REM change directory to ArmA directory (in which the server-exe resides)
 CD /D "%ArmaGameDir%"
 
 REM Start the server and minimize it once it's started
+ECHO Starting server...
 START /MIN %ArmaServerExe% -config=serverConfig.cfg -profiles=OPT_DevServer -filePatching -serverMod="%CLib_Dir%;%OPT-Server_Dir%" -mod="%OPT-Client_Dir%;%additionalMods%" -debugCallExtension
+
+REM Show live-serverlog if wanted
+IF ["%ShowServerLog%"] == ["TRUE"] (
+	ECHO Waiting a bit for the logfile being created...
+	CALL "%%~dp0.\..\helpers\sleep.bat" 2000
+	CALL "%%~dp0.\serverLog.bat" noPause
+)
 
 ECHO.
 ECHO Done.


### PR DESCRIPTION
- [x] Der Server-Starter kann jetzt ein Fenster mit live Logmeldungen des Servers anzeigen (muss in der Config aktiviert werden!)
- [x] CUP und Rosche vom Config-Beispiel entfernt (für die neue Livonia Kampagne)